### PR TITLE
fix: update management url for redbee

### DIFF
--- a/src/api/exposure.js
+++ b/src/api/exposure.js
@@ -1,7 +1,6 @@
 //const debug = require("debug")("mgmt");
 
-const EXPOSURE_API_ENDPOINT_PROD =
-  "https://exposure.api.redbee.live/v2";
+const EXPOSURE_API_ENDPOINT_PROD = "https://exposure.api.redbee.live/v2";
 const EXPOSURE_API_ENDPOINT_STAGE =
   "https://psempexposureapi.ebsd.ericsson.net/v2";
 const authService = require("../services/authService");

--- a/src/api/mgmt.js
+++ b/src/api/mgmt.js
@@ -8,7 +8,7 @@ const productsService = require("../services/productsService");
 
 const BaseApi = require("../utils/baseApi");
 
-const MGMT_API_ENDPOINT_PROD = "https://managementapi.emp.ebsd.ericsson.net";
+const MGMT_API_ENDPOINT_PROD = "https://management.api.redbee.live";
 const MGMT_API_ENDPOINT_STAGE =
   "https://psempempmanagementapi.ebsd.ericsson.net";
 
@@ -196,7 +196,7 @@ class EnigmaManagementAPI extends BaseApi {
     assetId,
     productId,
     startDate = new Date(),
-    publicationDurationInYears = 1
+    publicationDurationInYears = 1,
   ) {
     if (!this.bearerToken || !this.customerUnit || !this.businessUnit) return;
     const url = `${this.baseUrl}/v1/customer/${this.customerUnit}/businessunit/${this.businessUnit}/publication`;
@@ -213,7 +213,7 @@ class EnigmaManagementAPI extends BaseApi {
   async unpublishAsset(
     assetId,
     publicationId = undefined,
-    assetOnCustomerLevel = false
+    assetOnCustomerLevel = false,
   ) {
     if (!this.bearerToken || !this.customerUnit || !this.businessUnit) return;
     let url = `${this.baseUrl}/v1/customer/${this.customerUnit}/businessunit/${this.businessUnit}/asset/${assetId}/publication`;
@@ -234,7 +234,7 @@ class EnigmaManagementAPI extends BaseApi {
     name,
     description = "",
     anonymousAllowed = false,
-    entitlementRequired = true
+    entitlementRequired = true,
   ) {
     const product = {
       id,

--- a/tests/services/endUserService.test.js
+++ b/tests/services/endUserService.test.js
@@ -1,7 +1,7 @@
 const endUserService = require("../../src/services/endUserService");
 const base64 = require("base-64");
 
-const MGMT_API_ENDPOINT = "https://managementapi.emp.ebsd.ericsson.net/v2";
+const MGMT_API_ENDPOINT = "https://management.api.redbee.live/v2";
 const customerUnit = "Eyevinn";
 const businessUnit = "STSWE";
 const apiKeyId = process.env.API_KEY_ID;


### PR DESCRIPTION
The current management url for redbee is deprecated and should be updated to the new url.